### PR TITLE
Fix JS parsing error and enable CST example

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             <p>ATS Enabled: <span id="atsEnabled"></span></p>
             <p>Envelope Available: <span id="atsEnvelopeValue"></span></p>
             <button onclick="checkForEnvelope()">Check for Envelope</button>
-            <button onclick="triggerCST("hello=world,foo=bar")">Trigger CST</button>
+            <button onclick="triggerCST('hello=world,foo=bar')">Trigger CST</button>
         </div>
 
 
@@ -80,8 +80,8 @@ async function triggerCST(pdata) {
     var envString;
     var envImg;
     var consentString;
-    var pid =     // <YOUR PID HERE>;
-    var pixelID = // <YOUR PIXEL ID HERE>;    
+    var pid = 13299;
+    var pixelID = 712110;
        
     consentString = await fetchCMPConsent();
 


### PR DESCRIPTION
JS parse error on page was preventing overriding event default logic from applying.
Added pixel IDs for CST examples and changed double quote to single to make the HTML parser happy.
